### PR TITLE
Add flag to optionally include (or exclude) source code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# clj-bugsnag [![Build Status](https://travis-ci.org/whitepages/clj-bugsnag.svg)](https://travis-ci.org/whitepages/clj-bugsnag)
+# clj-bugsnag
 
 A fully fledged [Bugsnag](https://bugsnag.com) exception reporting client for Clojure.
 
@@ -17,23 +17,8 @@ A fully fledged [Bugsnag](https://bugsnag.com) exception reporting client for Cl
 
 ## Releases and Dependency Information
 
-clj-bugsnag is released via [Clojars](https://clojars.org/whitepages/clj-bugsnag). The Latest stable release is 0.3.0
-
-[Leiningen](https://github.com/technomancy/leiningen) dependency information:
-
-```clojure
-[whitepages/clj-bugsnag "0.3.0"]
-```
-
-Maven dependency information:
-
-```xml
-<dependency>
-  <groupId>whitepages</groupId>
-  <artifactId>clj-bugsnag</artifactId>
-  <version>0.3.0</version>
-</dependency>
-```
+The latest version of clj-bugsnag is currently only available via [git-deps](https://clojure.org/guides/deps_and_cli#_using_git_libraries),
+but there is an older version, 0.4.0, available via [Clojars](https://clojars.org/whitepages/clj-bugsnag).
 
 
 ## Example Usage

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
-{:paths ["src" "target/classes"],
+{:paths     ["src" "target/classes"]
  :deps
- {org.clojure/clojure #:mvn{:version "1.8.0"},
-  clj-stacktrace #:mvn{:version "0.2.8"},
-  clj-http #:mvn{:version "2.0.0"},
-  cheshire #:mvn{:version "5.5.0"},
-  environ #:mvn{:version "1.0.2"},
-  org.clojure/data.json #:mvn{:version "0.2.6"}},
+ {org.clojure/clojure           #:mvn{:version "1.8.0"}
+  clj-stacktrace/clj-stacktrace #:mvn{:version "0.2.8"}
+  clj-http/clj-http             #:mvn{:version "2.0.0"}
+  cheshire/cheshire             #:mvn{:version "5.5.0"}
+  environ/environ               #:mvn{:version "1.0.2"}
+  org.clojure/data.json         #:mvn{:version "0.2.6"}}
  :mvn/repos {}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["src" "target/classes"],
+ :deps
+ {org.clojure/clojure #:mvn{:version "1.8.0"},
+  clj-stacktrace #:mvn{:version "0.2.8"},
+  clj-http #:mvn{:version "2.0.0"},
+  cheshire #:mvn{:version "5.5.0"},
+  environ #:mvn{:version "1.0.2"},
+  org.clojure/data.json #:mvn{:version "0.2.6"}},
+ :mvn/repos {}}

--- a/project.clj
+++ b/project.clj
@@ -6,15 +6,15 @@
   :min-lein-version "2.3.0"
   :dependencies [
     [org.clojure/clojure "1.8.0"]
-    [clj-stacktrace "0.2.8"]
-    [clj-http "2.0.0"]
-    [cheshire "5.5.0"]
-    [environ "1.0.2"]
+    [clj-stacktrace/clj-stacktrace "0.2.8"]
+    [clj-http/clj-http "2.0.0"]
+    [cheshire/cheshire "5.5.0"]
+    [environ/environ "1.0.2"]
     [org.clojure/data.json "0.2.6"]]
 
   :aliases {
     "test" ["midje"]}
   :profiles {
     :dev {
-      :dependencies [[midje "1.9.9" :exclusions [potemkin riddley]]]
-      :plugins      [[lein-midje "3.2.1"]]}})
+      :dependencies [[midje/midje "1.9.9" :exclusions [potemkin riddley]]]
+      :plugins      [[lein-midje/lein-midje "3.2.1"]]}})

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -31,13 +31,13 @@
       nil)))
 
 (defn- transform-stacktrace
-  [trace-elems project-ns]
+  [trace-elems project-ns include-src?]
   (try
     (vec (for [{:keys [file line ns]
                 :as   elem} trace-elems
                :let         [project? (string/starts-with? (or ns "_") project-ns)
                              method   (method-str elem)
-                             code     (when (string/ends-with? (or file "") ".clj")
+                             code     (when (and include-src? (string/ends-with? (or file "") ".clj"))
                                         (find-source-snippet line (string/replace (or method "") "[fn]" "")))]]
            {:file       file
             :lineNumber line
@@ -58,11 +58,11 @@
     thing
     (str thing)))
 
-(defn- unroll [ex project-ns]
+(defn- unroll [ex project-ns include-src?]
   (loop [collected []
          current   ex]
     (let [class-name (.getName ^Class (:class current))
-          stacktrace (transform-stacktrace (:trace-elems current) project-ns)
+          stacktrace (transform-stacktrace (:trace-elems current) project-ns include-src?)
           new-item   {:errorClass class-name
                       :message    (:message current)
                       :stacktrace stacktrace}
@@ -72,23 +72,25 @@
         collected))))
 
 (defn exception->json
-  [exception {:keys [api-key project-ns context group group-fn user severity version environment meta]
-              :or   {api-key     (env :bugsnag-key)
-                     project-ns  "\000"
-                     severity    "error"
-                     version     @git-rev
-                     environment "production"}}]
-  (let [ex         (parse-exception exception)
-        class-name (.getName ^Class (:class ex))
-        base-meta  (if-let [d (ex-data exception)]
-                     {"ex–data" d}
-                     {})]
+  [exception {:keys [api-key project-ns context group group-fn user
+                     severity version environment meta include-src?]
+              :or   {api-key      (env :bugsnag-key)
+                     project-ns   "\000"
+                     severity     "error"
+                     version      @git-rev
+                     environment  "production"
+                     include-src? true}
+              :as   options}]
+  (let [ex        (parse-exception exception)
+        base-meta (if-let [d (ex-data exception)]
+                    {"ex–data" d}
+                    {})]
     {:apiKey   api-key
      :notifier {:name    "clj-bugsnag"
                 :version "0.3.0"
                 :url     "https://github.com/whitepages/clj-bugsnag"}
      :events   [{:payloadVersion "2"
-                 :exceptions     (unroll ex project-ns)
+                 :exceptions     (unroll ex project-ns include-src?)
                  :context        context
                  :groupingHash   (if group-fn
                                    (group-fn ex)

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -87,8 +87,8 @@
                     {})]
     {:apiKey   api-key
      :notifier {:name    "clj-bugsnag"
-                :version "0.3.0"
-                :url     "https://github.com/whitepages/clj-bugsnag"}
+                :version "0.5.0"
+                :url     "https://github.com/ekataglobal/clj-bugsnag"}
      :events   [{:payloadVersion "2"
                  :exceptions     (unroll ex project-ns include-src?)
                  :context        context

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -42,6 +42,15 @@
               24 ""
               25 "    (closure)))"})))
 
+(fact "does not include source in stack traces when option `include-src?` is false"
+        (try
+          (make-crash)
+          (catch Exception ex
+            (-> (core/exception->json ex {:include-src? false}) :events first :exceptions first :stacktrace second :code)
+            => nil
+            (-> (core/exception->json ex {:include-src? false}) :events first :exceptions first :stacktrace (nth 2) :code)
+            => nil)))
+
 (fact "falls back to BUGSNAG_KEY environment var for :apiKey"
       (-> (core/exception->json (ex-info "BOOM" {}) {}) :apiKey) => ..bugsnag-key..
       (provided


### PR DESCRIPTION
Allows users to set the boolean `:include-src?` key in the `opts` map to enable or disable source code snippets in the stack trace. Defaults to `true`.

For background, including source snippets results in a call to `clojure.repl/source-fn` for each stack trace element. This both reads the file and invokes the Clojure reader which can be rather expensive in the case of many errors with long stack traces. This has caused performance issues for us in some instances.